### PR TITLE
fix(ci): use GITHUB_TOKEN for bump version workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: true
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           changelog_increment_filename: body.md
           commit: true
           push: true
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
- Replace PERSONAL_ACCESS_TOKEN with GITHUB_TOKEN throughout
- This ensures commits are made by github-actions[bot] instead of user
- Resolves 'Permission denied to aycandv' authentication errors

🤖 Generated with [Claude Code](https://claude.ai/code)